### PR TITLE
Update layout template

### DIFF
--- a/telescope-theme-sm-colossus/package.js
+++ b/telescope-theme-sm-colossus/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-colossus",
   summary: "Telescope Scopemount: Colossus theme package",
-  version: "0.1.1",
+  version: "0.1.2",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-galileo/package.js
+++ b/telescope-theme-sm-galileo/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-galileo",
   summary: "Telescope Scopemount: Galileo theme package",
-  version: "0.1.8",
+  version: "0.1.9",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-gemini/package.js
+++ b/telescope-theme-sm-gemini/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-gemini",
   summary: "Telescope Scopemount: Gemini theme package",
-  version: "0.1.9",
+  version: "0.1.10",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-laval/package.js
+++ b/telescope-theme-sm-laval/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-laval",
   summary: "Telescope Scopemount: Laval theme package",
-  version: "0.1.0",
+  version: "0.1.1",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-lulin/package.js
+++ b/telescope-theme-sm-lulin/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-lulin",
   summary: "Telescope Scopemount: Lulin theme package",
-  version: "0.1.4",
+  version: "0.1.5",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-magellan/lib/client/templates/layout_magellan.html
+++ b/telescope-theme-sm-magellan/lib/client/templates/layout_magellan.html
@@ -9,9 +9,9 @@
         {{> messages}}
         {{> modules "hero"}}
         {{> yield "adminMenu"}}
-        {{> yield "postsListTop"}}
+        {{> yield "top"}}
         {{> yield}}
-        {{> footer}}
+        {{> footer_code}}
       </div>
       <div class="right-column">
         {{> modules "magellanSidebar"}}

--- a/telescope-theme-sm-magellan/package.js
+++ b/telescope-theme-sm-magellan/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-magellan",
   summary: "Telescope Scopemount: Magellan theme package",
-  version: "0.1.0",
+  version: "0.1.1",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-newton/package.js
+++ b/telescope-theme-sm-newton/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-newton",
   summary: "Telescope Scopemount: Newton theme package",
-  version: "0.1.8",
+  version: "0.1.9",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-palomar/package.js
+++ b/telescope-theme-sm-palomar/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-palomar",
   summary: "Telescope Scopemount: Palomar theme package",
-  version: "0.1.8",
+  version: "0.1.9",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-sloan/package.js
+++ b/telescope-theme-sm-sloan/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-sloan",
   summary: "Telescope Scopemount: Sloan theme package",
-  version: "0.1.5",
+  version: "0.1.6",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 

--- a/telescope-theme-sm-starfire/package.js
+++ b/telescope-theme-sm-starfire/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "montecruiseto:telescope-theme-sm-starfire",
   summary: "Telescope Scopemount: Starfire theme package",
-  version: "0.1.4",
+  version: "0.1.5",
   git: "https://github.com/montecruiseto/scopemount.git"
 });
 


### PR DESCRIPTION
Hi!

I noticed a template error related to inclusion of the _nav_ template after upgrading to Telescope v0.22.1. 

I read the **Template Refactoring** section of [Telescope v0.22.1 “DebugScope”](http://www.telescopeapp.org/blog/telescope-v0221-debugscope/) and updated `lib/client/templates/layout_magellan.html` in my Magellan themed site for the renamed templates and module zones.

I suppose all themes would need this updated for v0.22.x minimum compatibility.

Cheers!
