### PR TITLE
Updated magellan theme to work with Telescope 0.25.6

### DIFF
--- a/telescope-theme-sm-colossus/package.js
+++ b/telescope-theme-sm-colossus/package.js
@@ -28,7 +28,6 @@ Package.onUse(function (api) {
       'lib/client/scss/partials/_colors.scss',
 
       // globals
-      'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_links.scss',
       'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_markdown.scss',

--- a/telescope-theme-sm-galileo/package.js
+++ b/telescope-theme-sm-galileo/package.js
@@ -28,7 +28,6 @@ Package.onUse(function (api) {
 
   api.addFiles([
       // globals
-      'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_links.scss',
       'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_markdown.scss',

--- a/telescope-theme-sm-laval/package.js
+++ b/telescope-theme-sm-laval/package.js
@@ -28,7 +28,6 @@ Package.onUse(function (api) {
       'lib/client/scss/partials/_colors.scss',
 
       // globals
-      'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_links.scss',
       'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_markdown.scss',

--- a/telescope-theme-sm-lulin/package.js
+++ b/telescope-theme-sm-lulin/package.js
@@ -26,7 +26,6 @@ Package.onUse(function (api) {
       'lib/client/main.html',
 
       // globals
-      'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_links.scss',
       'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_markdown.scss',

--- a/telescope-theme-sm-magellan/lib/client/templates/categories_magellan.js
+++ b/telescope-theme-sm-magellan/lib/client/templates/categories_magellan.js
@@ -4,11 +4,7 @@ Meteor.startup(function () {
       return Categories.find({}, {sort: {order: 1, name: 1}});
     },
     categoryLink: function(){
-      return getCategoryUrl(this.slug);
+      return Categories.getUrl(category);
     }
   });
 });
-
-getCategoryUrl = function(slug){
-  return Telescope.utils.getSiteUrl()+'category/'+slug;
-};

--- a/telescope-theme-sm-magellan/lib/client/templates/featured_posts_magellan.html
+++ b/telescope-theme-sm-magellan/lib/client/templates/featured_posts_magellan.html
@@ -2,7 +2,7 @@
     <div class="magellan-header">FEATURED POSTS</div>
     {{#each featured}}
     <div class="post {{#if sticky}}sticky{{/if}} {{inactiveClass}} {{postClass}}" id="{{_id}}">
-      {{> modules zone="postComponents" moduleClass="post-module"}}
+      {{> modules zone="postComponents" moduleClass="post-module" moduleData=this}}
     </div>
     {{/each}}
 </template>

--- a/telescope-theme-sm-magellan/lib/client/templates/layout_magellan.html
+++ b/telescope-theme-sm-magellan/lib/client/templates/layout_magellan.html
@@ -7,14 +7,16 @@
       <div class="content-wrapper">
       <div class="left-column">
         {{> messages}}
-        {{> modules "hero"}}
-        {{> yield "adminMenu"}}
-        {{> yield "top"}}
-        {{> yield}}
+        {{> modules zone="hero"}}
+        {{> Template.dynamic template=adminMenu}}
+        {{> modules zone="contentTop"}}
+        {{> Template.dynamic template=main}}
+        {{> modules zone="contentBottom"}}
         {{> footer_code}}
+        {{> modules zone="footer"}}
       </div>
       <div class="right-column">
-        {{> modules "magellanSidebar"}}
+        {{> modules zone="magellanSidebar"}}
       </div>
       </div>
       <div class="overlay hidden"></div>

--- a/telescope-theme-sm-magellan/lib/client/templates/post_title_magellan.html
+++ b/telescope-theme-sm-magellan/lib/client/templates/post_title_magellan.html
@@ -1,3 +1,3 @@
 <template name="post_title_magellan">
-  <a href="{{pathFor 'post_page'}}" class="post-title">{{title}}</a>
+  <a href="{{this.getPageUrl}}" class="post-title">{{title}}</a>
 </template>

--- a/telescope-theme-sm-magellan/lib/client/templates/post_vote_magellan.html
+++ b/telescope-theme-sm-magellan/lib/client/templates/post_vote_magellan.html
@@ -1,15 +1,17 @@
 <template name="post_vote_magellan">
-  <div class="vote-actions {{actionsClass}}">
-    <a class="vote-action upvote-link" href="#" title="{{_ "upvote_"}}">
-      {{{icon "upvote"}}}
-      <span class="sr-only">{{_ "upvote_"}}</span>
-    </a>
-    <span class="points">{{baseScore}}</span>
-    {{#if enableDownvotes}}
-      <a class="vote-action downvote-link" href="#" title="{{_ "downvote_"}}">
-        {{{icon "downvote"}}}
-        <span class="sr-only">{{_ "downvote_"}}</span>
+  <div class="post-vote {{moduleClass}}">
+    <div class="vote-actions {{actionsClass}}">
+      <a class="vote-action upvote-link" href="#" title="{{_ "upvote_"}}">
+        {{{icon "upvote"}}}
+        <span class="sr-only">{{_ "upvote_"}}</span>
       </a>
-    {{/if}}
+      <span class="points">{{baseScore}}</span>
+      {{#if enableDownvotes}}
+        <a class="vote-action downvote-link" href="#" title="{{_ "downvote_"}}">
+          {{{icon "downvote"}}}
+          <span class="sr-only">{{_ "downvote_"}}</span>
+        </a>
+      {{/if}}
+    </div>
   </div>
 </template>

--- a/telescope-theme-sm-palomar/package.js
+++ b/telescope-theme-sm-palomar/package.js
@@ -26,7 +26,6 @@ Package.onUse(function (api) {
       'lib/client/main.html',
 
       // globals
-      'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_links.scss',
       'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_markdown.scss',

--- a/telescope-theme-sm-sloan/package.js
+++ b/telescope-theme-sm-sloan/package.js
@@ -22,7 +22,6 @@ Package.onUse(function (api) {
 
   api.addFiles([
       // globals
-      'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_links.scss',
       'lib/client/scss/global/_forms.scss',
       'lib/client/scss/global/_markdown.scss',


### PR DESCRIPTION
I've made some updates so that the theme no longer errors with the current version of telescope.

I haven't updated the css to work fully - I'm assuming there have since been some changes to the hubble theme that means some of the paddings and margins are a bit off.

There may also be bits that I haven't noticed, but I have gone through the demo site trying to make sure that it's at least functional.
